### PR TITLE
make nsd nodule future parser compatible

### DIFF
--- a/manifests/remote.pp
+++ b/manifests/remote.pp
@@ -17,7 +17,7 @@ class nsd::remote (
   $config_file = $nsd::params::config_file
 
   concat::fragment { 'nsd-remote':
-    order   => 10,
+    order   => '10',
     target  => $config_file,
     content => template('nsd/remote.erb'),
   }


### PR DESCRIPTION
stumbled upon that one with parser = future and puppet 3.7
