### PR TITLE
Allow current concat versions

### DIFF
--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: '5.2.0'
     concat:
       repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
-      ref: '6.4.0'
+      ref: 'v6.4.0'
   symlinks:
     nsd: "#{source_dir}"

--- a/.fixtures.yml
+++ b/.fixtures.yml
@@ -5,6 +5,6 @@ fixtures:
       ref: '5.2.0'
     concat:
       repo: "https://github.com/puppetlabs/puppetlabs-concat.git"
-      ref: '1.2.1'
+      ref: '6.4.0'
   symlinks:
     nsd: "#{source_dir}"

--- a/metadata.json
+++ b/metadata.json
@@ -33,7 +33,7 @@
   "dependencies": [
     {
       "name": "puppetlabs/concat",
-      "version_requirement": ">= 1.2.1 < 2.0.0"
+      "version_requirement": ">= 1.2.1 < 7.0.0"
     },
     {
       "name": "puppetlabs/stdlib",

--- a/spec/classes/init_spec.rb
+++ b/spec/classes/init_spec.rb
@@ -26,7 +26,7 @@ describe 'nsd' do
         let(:database) { '/var/db/nsd/nsd.db' }
       end
 
-      let(:facts) { facts.merge(concat_basedir: '/dne') }
+      let(:facts) { facts }
       let(:package_name) { 'nsd' }
 
       context 'with default params' do


### PR DESCRIPTION
The concat API hasn't changed since forever so this should be safe.  Concat 2.x no longer has concat_basedir so this can be removed from the tests.

This replaces https://github.com/voxpupuli/puppet-nsd/pull/17