### PR TITLE
add Debian support, add control_setup_cmd, actually use control_cmd 

### DIFF
--- a/data/os/Debian.yaml
+++ b/data/os/Debian.yaml
@@ -1,0 +1,11 @@
+---
+nsd::config_d: '/etc/nsd'
+nsd::config_file: '/etc/nsd/nsd.conf'
+nsd::zonedir: '/etc/nsd/zones'
+nsd::package_name: 'nsd'
+nsd::service_name: 'nsd'
+nsd::owner: 'nsd'
+nsd::group: 'nsd'
+nsd::control_cmd: '/usr/bin/echo /usr/sbin/nsd-control'
+nsd::control_setup_cmd: '/usr/sbin/nsd-control-setup'
+nsd::database: '/var/lib/nsd/nsd.db'

--- a/data/os/FreeBSD.yaml
+++ b/data/os/FreeBSD.yaml
@@ -7,5 +7,6 @@ nsd::service_name: 'nsd'
 nsd::owner: 'nsd'
 nsd::group: 'nsd'
 nsd::control_cmd: 'nsd-control'
+nsd::control_setup_cmd: 'nsd-control-setup'
 nsd::database: '/var/db/nsd/nsd.db'
 

--- a/data/os/OpenBSD.yaml
+++ b/data/os/OpenBSD.yaml
@@ -6,5 +6,6 @@ nsd::service_name: 'nsd'
 nsd::owner: '_nsd'
 nsd::group: '_nsd'
 nsd::control_cmd: 'nsd-control'
+nsd::control_setup_cmd: 'nsd-control-setup'
 nsd::database: '/var/nsd/db/nsd.db'
 

--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -8,6 +8,7 @@ class nsd (
   String $service_name,
   Variant[String,Undef] $package_name,
   String $control_cmd,
+  String $control_setup_cmd,
   String $zonedir,
   Boolean $zonepurge, # purge of unmanaged zone files
   String $group,
@@ -51,18 +52,18 @@ class nsd (
   }
 
   exec { 'nsd-control-setup':
-    command => 'nsd-control-setup',
+    command => $control_setup_cmd,
     creates => "${config_d}/nsd_control.pem",
   }
 
   exec { 'nsd-control reload':
-    command     => 'nsd-control reload',
+    command     => "${control_cmd} reload",
     refreshonly => true,
     require     => Service[$service_name],
   }
 
   exec { 'nsd-control reconfig':
-    command     => 'nsd-control reconfig',
+    command     => "${control_cmd} reconfig",
     refreshonly => true,
     require     => Service[$service_name],
   }

--- a/manifests/zone.pp
+++ b/manifests/zone.pp
@@ -41,7 +41,7 @@ define nsd::zone (
   }
 
   exec { "nsd-control reload ${name}":
-    command     => "nsd-control reload ${name}",
+    command     => "${nsd::control_cmd} reload ${name}",
     refreshonly => true,
     require     => [Concat[$config_file], Service[$nsd::service_name],],
   }


### PR DESCRIPTION

<!--
Thank you for contributing to this project!

- This project has a Contributor Code of Conduct: https://voxpupuli.org/coc/
- Please check that here is no existing issue or PR that addresses your problem.
- Our vulnerabilities reporting process is at https://voxpupuli.org/security/

-->
#### Pull Request (PR) description

* add Debian support
* control_cmd was not used, now it is
* add control_setup_cmd as Puppet now requires it to be an absolute path (I put in commands without paths for FreeBSD/OpenBSD that will need to be updated in relevant Puppet versions - but control_cmd needs to be updated for them anyway, so this is not worse than the current situation)


#### This Pull Request (PR) fixes the following issues
<!--
Replace this comment with the list of issues or n/a.
Use format:
Fixes #123
Fixes #124
-->
